### PR TITLE
feat: Auto-initialize VulnZap in 'secure' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "bundle": "esbuild src/cli.ts --bundle --outfile=dist/bundle.js --platform=node --format=esm --external:commander --external:chalk --external:ora --external:axios --external:@modelcontextprotocol/sdk/*",
     "prepublishOnly": "npm run build",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "start": "node dist/index.js",
@@ -82,6 +83,7 @@
     "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
+    "esbuild": "^0.25.3",
     "eslint": "^8.53.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { program } from 'commander';
+import { Command } from 'commander';
 import chalk from 'chalk';
-import ora from 'ora';
+import ora, { Ora } from 'ora';
 import { startMcpServer, checkVulnerability } from './index.js';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -15,6 +15,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));
 const version = packageJson.version;
+
+const program = new Command(); // Instantiate Command
 
 async function checkInit() {
   const vulnzapLocation = process.cwd() + '/.vulnzap-core';
@@ -52,44 +54,84 @@ program
    * automatically perform the initialization steps before starting the server.
    */
   .action(async (options) => {
-    displayBanner();
+    let originalConsoleLog;
 
-    const checkAlreadyInitialized = await checkInit();
-    if (!checkAlreadyInitialized) {
-      console.log(chalk.yellow('VulnZap not initialized. Initializing now...'));
-      const spinner = ora('Initializing VulnZap...').start();
-      try {
-        const vulnzapLocation = process.cwd() + '/.vulnzap-core';
-        if (!fs.existsSync(vulnzapLocation)) {
-          fs.mkdirSync(vulnzapLocation);
-        }
-        const scanConfigLocation = vulnzapLocation + '/scans.json';
-        if (!fs.existsSync(scanConfigLocation)) {
-          fs.writeFileSync(scanConfigLocation, JSON.stringify({
-            scans: []
-          }, null, 2));
-        }
-        spinner.succeed('VulnZap initialized successfully.');
-         // Optionally add the env variable hints here if desired
-        // console.log(chalk.yellow('To enable GitHub integration, set the VULNZAP_GITHUB environment variable with your GitHub token'));
-        // console.log(chalk.yellow('To enable National Vulnerability Database(NVD) integration, set the VULNZAP_NVD environment variable with your NVD token'));
-      } catch (error: any) {
-        spinner.fail('Failed to auto-initialize VulnZap');
-        console.error(chalk.red('Error:'), error.message);
-        process.exit(1);
-      }
+    // If running for an IDE via stdio, suppress stdout logging
+    if (options.ide) {
+      originalConsoleLog = console.log; // Store original
+      console.log = (..._args: any[]) => {}; // Override console.log with no-op
     }
 
-    // Proceed with starting the server
     try {
+      // Display banner only if not in IDE mode (now handled by console.log override)
+      // if (!options.ide) {
+      //   displayBanner(); 
+      // }
+      displayBanner(); // Keep banner logic, but it won't print if console.log is overridden
+
+      const checkAlreadyInitialized = await checkInit();
+      if (!checkAlreadyInitialized) {
+        let spinner: Ora | undefined;
+        // Spinner setup logic needs adjustment if console.log is overridden
+        // We can use ora directly, assuming its non-text output goes to stderr or is safe.
+        // Or, just skip the spinner entirely in IDE mode.
+        if (!options.ide) { 
+          console.log(chalk.yellow('VulnZap not initialized. Initializing now...'));
+          spinner = ora('Initializing VulnZap...').start();
+        } else {
+          spinner = ora().start(); // Start spinner silently
+        }
+        
+        try {
+          const vulnzapLocation = process.cwd() + '/.vulnzap-core';
+          if (!fs.existsSync(vulnzapLocation)) {
+            fs.mkdirSync(vulnzapLocation);
+          }
+          const scanConfigLocation = vulnzapLocation + '/scans.json';
+          if (!fs.existsSync(scanConfigLocation)) {
+            fs.writeFileSync(scanConfigLocation, JSON.stringify({
+              scans: []
+            }, null, 2));
+          }
+          
+          if (spinner) {
+            if (!options.ide) {
+                spinner.succeed('VulnZap initialized successfully.');
+            } else {
+                spinner.stop(); 
+            }
+          }
+
+          // Environment variable hints also suppressed by console.log override
+          // if (!options.ide) {
+          //   console.log(chalk.yellow('To enable GitHub integration...'));
+          //   console.log(chalk.yellow('To enable National Vulnerability Database(NVD) integration...'));
+          // }
+        } catch (error: any) {
+          if (spinner) spinner.fail('Failed to auto-initialize VulnZap'); 
+          console.error(chalk.red('Error:'), error.message); 
+          process.exit(1);
+        }
+      }
+
+      // Proceed with starting the server
       await startMcpServer({
         useMcp: options.mcp || true,
-        ide: options.ide || 'cursor',
+        ide: options.ide, 
         port: parseInt(options.port, 10),
       });
+
     } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
+      console.error(chalk.red('Error:'), error.message); // Use console.error for errors
+      if (options.ide && originalConsoleLog) {
+        console.log = originalConsoleLog; // Restore on error
+      }
       process.exit(1);
+    } finally {
+      // Ensure console.log is restored even if startMcpServer runs indefinitely or throws differently
+      if (options.ide && originalConsoleLog) {
+        console.log = originalConsoleLog; 
+      }
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,10 @@ export async function startMcpServer(config: VulnZapConfig): Promise<void> {
   // Start the server
   await server.connect(transport);
   
-  console.log("VulnZap MCP server started");
+  // Only log if not running in IDE mode
+  if (!config.ide) {
+    console.log("VulnZap MCP server started"); 
+  }
 }
 
 /**


### PR DESCRIPTION
This PR modifies the `vulnzap secure` command to automatically initialize VulnZap (create `.vulnzap-core` directory and `scans.json`) if it's not detected in the current project. This allows running `npx vulnzap-core secure` directly without needing a prior `vulnzap init`.